### PR TITLE
Upgrade requestJS to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "bluebird": "^3.1.5",
     "mime": "^1.3.4",
-    "request": "2.58.0"
+    "request": "^2.74.0"
   },
   "devDependencies": {
     "async": "0.2.9",


### PR DESCRIPTION
Upgrading requestJS to the latest version, since there is known vulnerabilities for versions prior to request@2.68.0.
